### PR TITLE
Added encoder for HL7 messages (pipehat format)

### DIFF
--- a/hl7/encoder.go
+++ b/hl7/encoder.go
@@ -1,0 +1,209 @@
+package hl7
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+var (
+	c_SEGMENT_SEPARATOR    = []byte{0x0d}
+	c_ESC_ESCAPE_CHAR      = []byte(`\E\`)
+	c_ESC_FIELD_SEP        = []byte(`\F\`)
+	c_ESC_REPETITION_SEP   = []byte(`\R\`)
+	c_ESC_COMPONENT_SEP    = []byte(`\S\`)
+	c_ESC_SUBCOMPONENT_SEP = []byte(`\T\`)
+)
+
+func Marshal(segments []Segment) ([]byte, error) {
+	if len(segments) == 0 {
+		return nil, errors.New("no data to marshal")
+	}
+
+	return NewEncoder(segments).Encode()
+}
+
+type Encoder struct {
+	segments        []Segment
+	segmentSep      []byte
+	charsToEscape   string
+	fieldSep        []byte
+	componentSep    []byte
+	repetitionSep   []byte
+	escapeChar      []byte
+	subcomponentSep []byte
+}
+
+// NewEncoder creates and initializes an Encoder for the provided slice of
+// Segment objects.  The slice must contain a valid message header (MSH) segment
+// with fields 1 and 2 populated with the field separator and separator characters;
+// if this segment is not present, the Encoder will not output a valid HL7 message.
+func NewEncoder(segments []Segment) *Encoder {
+	result := &Encoder{segments: segments}
+
+	result.segmentSep = c_SEGMENT_SEPARATOR
+
+	// find MSH segment and get delimiters
+	for _, s := range segments {
+		name, _ := result.fieldDataAt(s, 0)
+		if string(name) == "MSH" {
+			fs, _ := result.fieldDataAt(s, 1)
+			if len(fs) >= 1 {
+				result.fieldSep = []byte{fs[0]}
+			}
+
+			delims, _ := result.fieldDataAt(s, 2)
+			if len(delims) >= 4 {
+				result.componentSep = []byte{delims[0]}
+				result.repetitionSep = []byte{delims[1]}
+				result.escapeChar = []byte{delims[2]}
+				result.subcomponentSep = []byte{delims[3]}
+			}
+
+			// need to escape everything in the separator chars field plus the
+			// field separator character.
+			result.charsToEscape = fmt.Sprintf("%s%s", string(delims), string(fs))
+
+			break
+		}
+	}
+
+	return result
+}
+
+// Encode converts the slice of Segments stored in the Encoder to a byte slice
+// containing an encoded HL7 message.
+func (e *Encoder) Encode() (buf []byte, err error) {
+	for _, s := range e.segments {
+		enc, err := e.encodeSegment(s)
+		if err != nil {
+			return nil, err
+		}
+		// each segment must end in segmentSep, which is slightly different than
+		// other delimiters which do not appear at the end of a series (e.g.
+		// component1^component2).
+		buf = append(buf, enc...)
+		buf = append(buf, e.segmentSep...)
+	}
+
+	return buf, nil
+}
+
+func (e *Encoder) fieldDataAt(segment Segment, index int) ([]byte, error) {
+	data, _ := segment.Index(index)
+	switch v := data.(type) {
+	case Field:
+		return data.(Field), nil
+	default:
+		return nil, fmt.Errorf("cannot get field data for type %T", v)
+	}
+
+	return nil, errors.New("unexpected field data decoding error")
+}
+
+func (e *Encoder) encodeData(data Data) (buf []byte, err error) {
+	switch v := data.(type) {
+
+	case Field:
+		// Field is a byte array
+		buf = data.(Field)
+
+		// escape any separator characters in the field data, if present
+		// http://www.hl7standards.com/blog/2006/11/02/hl7-escape-sequences/
+
+		if bytes.IndexAny(buf, e.charsToEscape) > -1 {
+			buf = bytes.Replace(buf, e.escapeChar, c_ESC_ESCAPE_CHAR, -1)
+			buf = bytes.Replace(buf, e.fieldSep, c_ESC_FIELD_SEP, -1)
+			buf = bytes.Replace(buf, e.componentSep, c_ESC_COMPONENT_SEP, -1)
+			buf = bytes.Replace(buf, e.repetitionSep, c_ESC_REPETITION_SEP, -1)
+			buf = bytes.Replace(buf, e.subcomponentSep, c_ESC_SUBCOMPONENT_SEP, -1)
+		}
+
+	case SubComponent:
+		// SubComponent is array of fields delimited by subcomponentSep
+		var b [][]byte
+		subcomponent := data.(SubComponent)
+		l := subcomponent.Len()
+		for i := 0; i < l; i++ {
+			d, _ := subcomponent.Index(i)
+			enc, err := e.encodeData(d)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, enc)
+		}
+		buf = bytes.Join(b, e.subcomponentSep)
+		break
+
+	case Component:
+		// Component contains fields and subcomponents
+		var b [][]byte
+		component := data.(Component)
+		l := component.Len()
+		for i := 0; i < l; i++ {
+			d, _ := component.Index(i)
+			enc, err := e.encodeData(d)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, enc)
+		}
+		buf = bytes.Join(b, e.componentSep)
+		break
+
+	case Repeated:
+		// Repeated contains fields, subcomponents, and components
+		var b [][]byte
+		repeated := data.(Repeated)
+		l := repeated.Len()
+		for i := 0; i < l; i++ {
+			d, _ := repeated.Index(i)
+			enc, err := e.encodeData(d)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, enc)
+		}
+		buf = bytes.Join(b, e.repetitionSep)
+		break
+
+	default:
+		return nil, fmt.Errorf("unrecognized type: %T", v)
+	}
+
+	return
+}
+
+func (e *Encoder) encodeSegment(segment Segment) (buf []byte, err error) {
+	l := segment.Len()
+
+	// TODO add first field
+	var b [][]byte
+
+	for i := 0; i < l; i++ {
+		data, _ := segment.Index(i)
+		enc, err := e.encodeData(data)
+		if err != nil {
+			return nil, err
+		}
+
+		if string(enc) == "MSH" {
+			// add the segment name
+			b = append(b, enc)
+
+			// next two fields are the separators
+			// first, skip the field separator since we parsed it out in NewEncoder
+			i++
+
+			// next, get the separator characters without running through encode(),
+			// which will escape them.
+			i++
+			seps, _ := e.fieldDataAt(segment, i)
+			b = append(b, seps)
+		} else {
+			b = append(b, enc)
+		}
+	}
+
+	return bytes.Join(b, e.fieldSep), nil
+}

--- a/hl7/encoder_test.go
+++ b/hl7/encoder_test.go
@@ -1,0 +1,301 @@
+package hl7
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var (
+	simple_hl7_input = []Segment{
+		Segment{
+			Field("MSH"),
+			Field("|"),
+			Field(`^~\&`),
+			Field("field"),
+			Field(`\|~^&HEY`),
+			Component{
+				Field("component1"),
+				Field("component2"),
+			},
+			Component{
+				SubComponent{
+					Field("subcomponent1a"),
+					Field("subcomponent2a"),
+				},
+				SubComponent{
+					Field("subcomponent1b"),
+					Field("subcomponent2b"),
+				},
+			},
+			Repeated{
+				Component{
+					Field("component1a"),
+					Field("component2a"),
+				},
+				Component{
+					Field("component1b"),
+					Field("component2b"),
+				},
+			},
+		},
+	}
+
+	sample_hl7_input = []Segment{
+		Segment{
+			Field("MSH"),
+			Field("|"),
+			Field(`^~\&`),
+			Field(`EP^IC`),
+			Field("EPICADT"),
+			Field("SMS"),
+			Field("SMSADT"),
+			Field("199912271408"),
+			Field("CHARRIS"),
+			Component{
+				Field("ADT"),
+				Field("A04"),
+			},
+			Field("1817457"),
+			Field("D"),
+			Field("2.5"),
+			Field(""),
+		},
+		Segment{
+			Field("PID"),
+			Field(""),
+			Component{
+				Field("0493575"),
+				Field(""),
+				Field(""),
+				Field("2"),
+				Field("ID 1"),
+			},
+			Field("454721"),
+			Field(""),
+			Component{
+				Field("DOE"),
+				Field("JOHN"),
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+			},
+			Component{
+				Field("DOE"),
+				Field("JOHN"),
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+			},
+			Field("19480203"),
+			Field("M"),
+			Field(""),
+			Field("B"),
+			Component{
+				Field("254 MYSTREET AVE"),
+				Field(""),
+				Field("MYTOWN"),
+				Field("OH"),
+				Field("44123"),
+				Field("USA"),
+			},
+			Field(""),
+			Field("(216)123-4567"),
+			Field(""),
+			Field(""),
+			Field("M"),
+			Field("NON"),
+			Repeated{
+				Field("400003403"),
+				Field("1129086"),
+			},
+			Field(""),
+		},
+		Segment{
+			Field("NK1"),
+			Field(""),
+			Component{
+				Field("ROE"),
+				Field("MARIE"),
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+			},
+			Field("SPO"),
+			Field(""),
+			Field("(216)123-4567"),
+			Field(""),
+			Field("EC"),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+		},
+		Segment{
+			Field("PV1"),
+			Field(""),
+			Field("O"),
+			Component{
+				Repeated{
+					Field("168 "),
+					Field("219"),
+					Field("C"),
+					Field("PMA"),
+				},
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+			},
+			Field(""),
+			Field(""),
+			Field(""),
+			Component{
+				Field("277"),
+				Field("ALLEN MYLASTNAME"),
+				Field("BONNIE"),
+				Field(""),
+				Field(""),
+				Field(""),
+				Field(""),
+			},
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(" "),
+			Field(""),
+			Field("2688684"),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field("199912271408"),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(""),
+			Field(`002376853"`),
+		},
+	}
+)
+
+var marshalTests = []struct {
+	file string
+	in   []Segment
+}{
+	{"simple_nohex.hl7", simple_hl7_input},
+	{"sample.hl7", sample_hl7_input},
+}
+
+func TestMarshalFiles(t *testing.T) {
+	for i, tt := range marshalTests {
+		fp, err := os.Open("testdata/" + tt.file)
+		if err != nil {
+			t.Fatalf("#%d. received error: %s", i, err)
+		}
+		defer fp.Close()
+
+		expected, err := ioutil.ReadAll(fp)
+		if err != nil {
+			t.Fatalf("#%d. received error: %s", i, err)
+		}
+
+		actual, err := Marshal(tt.in)
+		if err != nil {
+			t.Fatalf("#%d. received error: %s", i, err)
+		}
+
+		if !bytes.Equal(actual, expected) {
+			if len(actual) != len(expected) {
+				ioutil.WriteFile(fmt.Sprintf("/tmp/bad%d.hl7", i), actual, 0777)
+				t.Fatalf("#%d: length mismatch\nhave: %d\nwant: %d", i, len(actual), len(expected))
+			} else {
+
+				loc := -1
+				l := len(actual)
+				if l > len(expected) {
+					l = len(expected)
+				}
+
+				for j := 0; j < l; j++ {
+					if actual[j] != expected[j] {
+						loc = j
+						break
+					}
+				}
+
+				sloc := loc - 5
+				if sloc < 0 {
+					sloc = 0
+				}
+
+				eloc := loc + 5
+				if eloc >= l {
+					eloc = l
+				}
+
+				t.Fatalf("#%d: mismatch at byte %d\nhave: %s (%v)\nwant: %s (%v)", i, loc, string(actual[sloc:eloc]), actual[sloc:eloc], string(expected[sloc:eloc]), expected[sloc:eloc])
+			}
+		}
+	}
+}

--- a/hl7/testdata/simple_nohex.hl7
+++ b/hl7/testdata/simple_nohex.hl7
@@ -1,0 +1,1 @@
+MSH|^~\&|field|\E\\F\\R\\S\\T\HEY|component1^component2|subcomponent1a&subcomponent2a^subcomponent1b&subcomponent2b|component1a^component2a~component1b^component2b


### PR DESCRIPTION
Added hl7.Encoder type and hl7.Marshal() function to convert HL7 objects to byte slices.  The Encoder is constructed with a slice of hl7.Segment structs, one of which must be a valid message header (MSH)
segment.  The delimiter characters are parsed from the MSH segment and used to encode all of the
segments into a []byte.