### PR TITLE
CCD: Support for <translation> codes in Problems

### DIFF
--- a/ccd/problems.go
+++ b/ccd/problems.go
@@ -1,8 +1,9 @@
 package ccd
 
 import (
-	"github.com/jteeuwen/go-pkg-xmlx"
 	"time"
+
+	"github.com/jteeuwen/go-pkg-xmlx"
 )
 
 var (
@@ -21,6 +22,7 @@ type Problem struct {
 	Date time.Time
 	// Duration time.Duration
 	Status string
+	Code   Code
 }
 
 func parseProblems(node *xmlx.Node, ccd *CCD) []error {
@@ -34,6 +36,15 @@ func parseProblems(node *xmlx.Node, ccd *CCD) []error {
 			continue
 		}
 		problem.Name = valueNode.As("*", "displayName")
+
+		translation := Nget(valueNode, "translation")
+		if translation != nil {
+			problem.Code.decode(translation)
+			//if the value node didnt have a displayName, try the translation node.
+			if problem.Name == "" && problem.Code.DisplayName != "" {
+				problem.Name = problem.Code.DisplayName
+			}
+		}
 
 		effectiveTimeNode := Nget(observationNode, "effectiveTime")
 		t := decodeTime(effectiveTimeNode)


### PR DESCRIPTION
Problem now contains a Code that is the <translation> tag. Additionally,
if we don't already have a displayName for this problem, we use the
displayName set in the translation tag.

I could not find any example CCDs with more than one translation tag, so
I'm not sure how this code behaves in that circumstance if that is
possible.