### PR TITLE
Update import path for gosexy/to

### DIFF
--- a/ccd/util.go
+++ b/ccd/util.go
@@ -2,7 +2,7 @@ package ccd
 
 import (
 	"github.com/jteeuwen/go-pkg-xmlx"
-	"menteslibres.net/gosexy/to"
+	"github.com/gosexy/to"
 	"strings"
 	"time"
 )


### PR DESCRIPTION
We're still importing from menteslibres.net/gosexy/to.   This still works fine for me locally thanks to the meta tag, but travis-ci has been failing.